### PR TITLE
Add very naive queue cache.

### DIFF
--- a/lib/SQS.js
+++ b/lib/SQS.js
@@ -13,6 +13,8 @@ import {
 
 const connectionString = config.db;
 
+var queues = {};
+
 export default class SQS {
 	constructor(options = {}) {
 		this.options = Object.assign({ region: "us-east-1", params: {} }, options);
@@ -343,6 +345,12 @@ function connectToQueue(queueUrl, callback) {
 		return callback(new Error("QueueUrl required"));
 	}
 
+	// queues[queueUrl] = {queue: queue, settings: settings}
+	if (queues[queueUrl]) {
+		var item = queues[queueUrl];
+		return callback(null, { queue: item.queue, settings: item.settings });
+	}
+
 	async.auto({
 		connect,
 		findSettings: ["connect", (results, cb) => {
@@ -357,6 +365,7 @@ function connectToQueue(queueUrl, callback) {
 					return cb();
 				}
 
+				queues[queueUrl] = { queue: mongodbQueue(db, queueUrl), settings: settings };
 				cb(null, { queue: mongodbQueue(db, queueUrl), settings });
 			});
 		}],
@@ -382,7 +391,8 @@ function connectToQueue(queueUrl, callback) {
 					return cb(err);
 				}
 
-				cb(null, { queue: mongodbQueue(db, queueUrl), settings });
+				queues[queueUrl] = { queue: mongodbQueue(db, queueUrl), settings: settings };
+				cb(null, queues[queueUrl]);
 			});
 		}]
 	}, (err, results) => {


### PR DESCRIPTION
This stops multiple sockets being opened for the same queue.

I have code that polls the queue and it was blowing up after just over 4000 sockets.  This change seems to have solved that problem.
